### PR TITLE
ci(docs): add a check for PR's to commit their doc changes

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -1,0 +1,11 @@
+name: Missing API docs
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - 'marvim/api-doc-update**'
+
+jobs:
+  call-regen-api-docs:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/api-docs.yml

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,3 +1,6 @@
+# Autogenerate the API docs on new commit to important branches
+# Also work as a check for PR's to not forget commiting their doc changes
+# called from api-docs-checks.yml)
 name: Autogenerate API docs
 on:
   push:
@@ -9,6 +12,12 @@ on:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      only_check:
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   regen-api-docs:
@@ -44,8 +53,14 @@ jobs:
           python3 scripts/gen_vimdoc.py
           printf '::set-output name=UPDATED_DOCS::%s\n' $([ -z "$(git diff)" ]; echo $?)
 
+      - name: FAIL, PR has not commited doc changes
+        if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && inputs.only_check }}
+        run: |
+          echo "Job failed, run ./scripts/gen_vimdoc.py and commit your doc changes"
+          exit 1
+
       - name: Automatic PR
-        if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 }}
+        if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && inputs.only_check }}
         run: |
           git add -u
           git commit -m 'docs: regenerate [skip ci]'


### PR DESCRIPTION
Repurpose the api-docs workflow to also run in all PR's but work only as
a check, if the changes in the PR introduce doc changes that are not
committed fail.

[skip ci]