### PR TITLE
ci(doc): missing docs workflow improvements

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -1,12 +1,13 @@
 name: Missing API docs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches-ignore:
       - 'marvim/api-doc-update**'
     paths:
       - 'src/nvim/api/*.[ch]'
       - 'runtime/lua/**.lua'
+      - 'runtime/doc/**'
 
 jobs:
   call-regen-api-docs:

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -56,6 +56,8 @@ jobs:
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && inputs.check_only }}
         run: |
           echo "Job failed, run ./scripts/gen_vimdoc.py and commit your doc changes"
+          echo "The doc generation produces the following changes:"
+          git diff
           exit 1
 
       - name: Automatic PR


### PR DESCRIPTION
1. Add new pattern `runtime/doc/**`. This is a common case were the
   contributor modifies only the help file but the doc gen would discard
   their changes.
2. Make "skip ci" not skip the workflow. Since one of the most
   common uses for skipping ci is just doc changes and that's when this
   workflow is actually needed.
3. Add to the output what the changes after running doc gen would be.

[skip ci]