### PR TITLE
ci(doc): missing docs workflow improvements

### DIFF
--- a/.github/workflows/api-docs-check.yml
+++ b/.github/workflows/api-docs-check.yml
@@ -1,12 +1,13 @@
 name: Missing API docs
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     branches-ignore:
       - 'marvim/api-doc-update**'
     paths:
       - 'src/nvim/api/*.[ch]'
       - 'runtime/lua/**.lua'
+      - 'runtime/doc/**'
 
 jobs:
   call-regen-api-docs:
@@ -17,3 +18,6 @@ jobs:
     uses: ./.github/workflows/api-docs.yml
     with:
       check_only: true
+      # The 'pull_request_target' event has $GITHUB_SHA as the last commit of
+      # the PR base branch (neovim/master), we need the actual PR branch HEAD
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         default: false
         required: false
+      ref:
+        type: string
+        default: ''
+        required: true
 
 jobs:
   regen-api-docs:
@@ -30,6 +34,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || env.GITHUB_SHA }}
 
       - name: Install dependencies
         run: |
@@ -56,6 +61,8 @@ jobs:
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 && inputs.check_only }}
         run: |
           echo "Job failed, run ./scripts/gen_vimdoc.py and commit your doc changes"
+          echo "The doc generation produces the following changes:"
+          git --no-pager diff
           exit 1
 
       - name: Automatic PR


### PR DESCRIPTION
1. Add new pattern `runtime/doc/**`. This is a common case were the
   contributor modifies only the help file but the doc gen would discard
   their changes.

2. Make "skip ci" not skip the workflow. Since one of the most
   common uses for skip ci is doc changes and that's when this
   workflow is actually needed.

   This is a accomplished by using pull_request_target but by default
   $GITHUB_SHA in this event is the last commit of the base branch
   (neovim master). Therefore generate the docs in the tip of the PR
   branch by providing a ref to the checkout action, which is also the
   same commit in which the user will run doc gen locally (should lead
   to less flakiness).

3. Add to the output what the changes after running doc gen would be.

[skip ci]